### PR TITLE
fixed installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ First, enable the plugins support in your Traefik configuration file (traefik.ym
 ```yaml
 experimental:
   plugins:
-    traefikkeycloak:
+    keycloakopenid:
       moduleName: "github.com/Gwojda/keycloakopenid"
-      version: "v0.1.30"
+      version: "v0.1.31"
 ```
 
 Usage


### PR DESCRIPTION
Traefik couldn't find the plugin and threw this error: `level=error msg="plugin: unknown plugin type: keycloakopenid"`.
The problem was that in the installation guide in the `Readme.md`, which I followed, the plugin was called "traefikkeycloak" in the `traefik.yml`, though the name should be "keycloakopenid". I changed that to help further users of the plugin to not get confused.

Also, the current version is now `v0.1.31`, previously `v0.1.30`.