### PR TITLE
Proposal: load config from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,11 @@ http:
 ```
 
 The above configuration will authenticate all incoming requests for mywebsite.com with Keycloak.
+
+Alternatively, the configuration can be loaded with environment variables for better synergy with K8s and Keycloak Realm Operator:
+```bash
+KEYCLOAKOPENID_KEYCLOAK_URL = "my-keycloak-url.com"
+KEYCLOAKOPENID_KEYCLOAK_CLIENT_ID = "<CLIENT_ID"
+KEYCLOAKOPENID_KEYCLOAK_CLIENT_SECRET = "<CLIENT_SECRET"
+KEYCLOAKOPENID_KEYCLOAK_REALM = "<REALM"
+```

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 )
@@ -41,6 +42,19 @@ func CreateConfig() *Config {
 }
 
 func New(ctx context.Context, next http.Handler, config *Config, name string) (http.Handler, error) {
+	if value, ok := os.LookupEnv("KEYCLOAKOPENID_KEYCLOAK_URL"); ok {
+		config.KeycloakURL = value
+	}
+	if value, ok := os.LookupEnv("KEYCLOAKOPENID_KEYCLOAK_CLIENT_ID"); ok {
+		config.ClientID = value
+	}
+	if value, ok := os.LookupEnv("KEYCLOAKOPENID_KEYCLOAK_CLIENT_SECRET"); ok {
+		config.ClientSecret = value
+	}
+	if value, ok := os.LookupEnv("KEYCLOAKOPENID_KEYCLOAK_REALM"); ok {
+		config.KeycloakRealm = value
+	}
+
 	if config.KeycloakURL == "" || config.ClientID == "" {
 		return nil, errors.New("invalid configuration")
 	}


### PR DESCRIPTION
It would be nice to have the ability to read the configuration from environment variables as well.

This may result in better synergy with K8s and the Keycloak realm operator, and it's a common practice to have the client ID and client secret in a k8s Secret CR instead of a hypothetical traefik ConfigMap.

Warning: no tested. I would appreciate someone's help to test