### PR TITLE
add support for complete url

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,8 +21,11 @@ type Config struct {
 }
 
 type keycloakAuth struct {
-	next   http.Handler
-	config *Config
+	next          http.Handler
+	KeycloakURL   *url.URL
+	ClientID      string
+	ClientSecret  string
+	KeycloakRealm string
 }
 
 type KeycloakTokenResponse struct {
@@ -40,14 +43,39 @@ func CreateConfig() *Config {
 	return &Config{}
 }
 
-func New(ctx context.Context, next http.Handler, config *Config, name string) (http.Handler, error) {
-	if config.KeycloakURL == "" || config.ClientID == "" {
+func parseUrl(rawUrl string) (*url.URL, error) {
+	if rawUrl == "" {
+		return nil, errors.New("invalid empty url")
+	}
+	if !strings.Contains(rawUrl, "://") {
+		rawUrl = "https://" + rawUrl
+	}
+	u, err := url.Parse(rawUrl)
+	if err != nil {
+		return nil, err
+	}
+	if !strings.HasPrefix(u.Scheme, "http") {
+		return nil, fmt.Errorf("%v is not a valid scheme", u.Scheme)
+	}
+	return u, nil
+}
+
+func New(uctx context.Context, next http.Handler, config *Config, name string) (http.Handler, error) {
+	if config.ClientID == "" || config.KeycloakRealm == "" {
 		return nil, errors.New("invalid configuration")
 	}
 
+	parsedURL, err := parseUrl(config.KeycloakURL)
+	if err != nil {
+		return nil, err
+	}
+
 	return &keycloakAuth{
-		next:   next,
-		config: config,
+		next:          next,
+		KeycloakURL:   parsedURL,
+		ClientID:      config.ClientID,
+		ClientSecret:  config.ClientSecret,
+		KeycloakRealm: config.KeycloakRealm,
 	}, nil
 }
 
@@ -137,13 +165,23 @@ func (k *keycloakAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 func (k *keycloakAuth) exchangeAuthCode(req *http.Request, authCode string, stateBase64 string) (string, error) {
 	stateBytes, _ := base64.StdEncoding.DecodeString(stateBase64)
 	var state state
-	json.Unmarshal(stateBytes, &state)
+	err := json.Unmarshal(stateBytes, &state)
+	if err != nil {
+		return "", err
+	}
 
-	resp, err := http.PostForm("https://"+k.config.KeycloakURL+"/realms/"+k.config.KeycloakRealm+"/protocol/openid-connect/token",
+	target := k.KeycloakURL.JoinPath(
+		"realms",
+		k.KeycloakRealm,
+		"protocol",
+		"openid-connect",
+		"token",
+	)
+	resp, err := http.PostForm(target.String(),
 		url.Values{
 			"grant_type":    {"authorization_code"},
-			"client_id":     {k.config.ClientID},
-			"client_secret": {k.config.ClientSecret},
+			"client_id":     {k.ClientID},
+			"client_secret": {k.ClientSecret},
 			"code":          {authCode},
 			"redirect_uri":  {state.RedirectURL},
 		})
@@ -179,17 +217,19 @@ func (k *keycloakAuth) redirectToKeycloak(rw http.ResponseWriter, req *http.Requ
 	stateBytes, _ := json.Marshal(state)
 	stateBase64 := base64.StdEncoding.EncodeToString(stateBytes)
 
-	redirectURL := url.URL{
-		Scheme: "https",
-		Host:   k.config.KeycloakURL,
-		Path:   "/realms/" + k.config.KeycloakRealm + "/protocol/openid-connect/auth",
-		RawQuery: url.Values{
-			"response_type": {"code"},
-			"client_id":     {k.config.ClientID},
-			"redirect_uri":  {originalURL},
-			"state":         {stateBase64},
-		}.Encode(),
-	}
+	redirectURL := k.KeycloakURL.JoinPath(
+		"realms",
+		k.KeycloakRealm,
+		"protocol",
+		"openid-connect",
+		"auth",
+	)
+	redirectURL.RawQuery = url.Values{
+		"response_type": {"code"},
+		"client_id":     {k.ClientID},
+		"redirect_uri":  {originalURL},
+		"state":         {stateBase64},
+	}.Encode()
 
 	http.Redirect(rw, req, redirectURL.String(), http.StatusFound)
 }
@@ -201,13 +241,24 @@ func (k *keycloakAuth) verifyToken(token string) (bool, error) {
 		"token": {token},
 	}
 
-	req, err := http.NewRequest(http.MethodPost, "https://"+k.config.KeycloakURL+"/realms/"+k.config.KeycloakRealm+"/protocol/openid-connect/token/introspect", strings.NewReader(data.Encode()))
+	req, err := http.NewRequest(
+		http.MethodPost,
+		k.KeycloakURL.JoinPath(
+			"realms",
+			k.KeycloakRealm,
+			"protocol",
+			"openid-connect",
+			"token",
+			"introspect",
+		).String(),
+		strings.NewReader(data.Encode()),
+	)
 	if err != nil {
 		return false, err
 	}
 
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.SetBasicAuth(k.config.ClientID, k.config.ClientSecret)
+	req.SetBasicAuth(k.ClientID, k.ClientSecret)
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -5,8 +5,138 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 )
+
+func TestParseURL(t *testing.T) {
+	var u *url.URL
+	var err error
+
+	u, err = parseUrl("")
+	if err == nil {
+		t.Fatal("should not accept empty url")
+	}
+
+	u, err = parseUrl("auth.bochslerfinance.com")
+	if err != nil {
+		t.Fatal("should not fail here, error was: ", err)
+	} else if u.Scheme != "https" {
+		t.Fatal("url without scheme should be auto-prefixed with 'https'")
+	} else if u.Host != "auth.bochslerfinance.com" {
+		t.Fatal("Host part should have been right parsed")
+	}
+
+	u, err = parseUrl("172.17.0.1:8443")
+	if err != nil {
+		t.Fatal("should not fail here. error was: ", err)
+	} else if u.Scheme != "https" {
+		t.Fatal("url without scheme should be auto-prefixed with 'https'")
+	} else if u.Host != "172.17.0.1:8443" {
+		t.Fatal("Host part should have been right parsed")
+	}
+
+	u, err = parseUrl("http://auth.bochslerfinance.com")
+	if err != nil {
+		t.Fatal("should not fail here. error was: ", err)
+	} else if u.Scheme != "http" {
+		t.Fatal("Scheme part should have been right parsed")
+	} else if u.Host != "auth.bochslerfinance.com" {
+		t.Fatal("Host part should have been right parsed")
+	}
+
+	u, err = parseUrl("https://auth.bochslerfinance.com")
+	if err != nil {
+		t.Fatal("should not fail here. error was: ", err)
+	} else if u.Scheme != "https" {
+		t.Fatal("Scheme part should have been right parsed")
+	} else if u.Host != "auth.bochslerfinance.com" {
+		t.Fatal("Host part should have been right parsed")
+	}
+
+	u, err = parseUrl("ftp://auth.bochslerfinance.com")
+	if !(err != nil && u == nil) {
+		t.Fatal("should not accept scheme other than http and https")
+	}
+
+	u, err = parseUrl("bochslerfinance.com/auth")
+	if err != nil {
+		t.Fatal("should not fail here. error was: ", err)
+	} else if u.Scheme != "https" {
+		t.Fatal("Scheme part should have been right parsed")
+	} else if u.Host != "bochslerfinance.com" {
+		t.Fatal("Host part should have been right parsed")
+	} else if u.Path != "/auth" {
+		t.Fatal("Path part should have been right parsed")
+	}
+
+	// special case wherekeycloak is hosted locally
+	// url will be https:///auth (no host part)
+	u, err = parseUrl("/auth")
+	if err != nil {
+		t.Fatal("should not fail here. error was: ", err)
+	} else if u.Scheme != "https" {
+		t.Fatal("Scheme part should have been right parsed")
+	} else if u.Host != "" {
+		t.Fatal("Host part should have been right parsed")
+	} else if u.Path != "/auth" {
+		t.Fatal("Path part should have been right parsed")
+	}
+}
+
+func TestSetup(t *testing.T) {
+	handlerFunc := http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	})
+
+	// Setup
+	config := CreateConfig()
+	config.KeycloakURL = "auth.bochslerfinance.com"
+	config.KeycloakRealm = "bochsler"
+	config.ClientID = "keycloakMiddleware"
+	config.ClientSecret = "uc0yKKpQsOqhggsG4eK7mDU3glT81chn"
+	_, err := New(context.TODO(), handlerFunc, config, "keycloak-openid")
+	if err != nil {
+		t.Fatal("Can't create middleware", err)
+	}
+
+	config = CreateConfig()
+	config.KeycloakRealm = "bochsler"
+	config.ClientID = "keycloakMiddleware"
+	config.ClientSecret = "uc0yKKpQsOqhggsG4eK7mDU3glT81chn"
+	_, err = New(context.TODO(), handlerFunc, config, "keycloak-openid")
+	if err == nil {
+		t.Fatal("should fail because no KeycloakURL")
+	}
+
+	config = CreateConfig()
+	config.KeycloakURL = "ftp://test.com"
+	config.KeycloakRealm = "bochsler"
+	config.ClientID = "keycloakMiddleware"
+	config.ClientSecret = "uc0yKKpQsOqhggsG4eK7mDU3glT81chn"
+	_, err = New(context.TODO(), handlerFunc, config, "keycloak-openid")
+	if err == nil {
+		t.Fatal("should fail because invalid KeycloakURL")
+	}
+
+	config = CreateConfig()
+	config.KeycloakURL = "auth.bochslerfinance.com"
+	config.ClientID = "keycloakMiddleware"
+	config.ClientSecret = "uc0yKKpQsOqhggsG4eK7mDU3glT81chn"
+	_, err = New(context.TODO(), handlerFunc, config, "keycloak-openid")
+	if err == nil {
+		t.Fatal("should fail because no realm")
+	}
+
+	config = CreateConfig()
+	config.KeycloakURL = "auth.bochslerfinance.com"
+	config.KeycloakRealm = "bochsler"
+	config.ClientSecret = "uc0yKKpQsOqhggsG4eK7mDU3glT81chn"
+	_, err = New(context.TODO(), handlerFunc, config, "keycloak-openid")
+	if err == nil {
+		t.Fatal("should fail beacause no ClientID")
+	}
+}
 
 func TestServeHTTP(t *testing.T) {
 	// Setup


### PR DESCRIPTION
In KeycloakURL you can now specify a "real" url like `https://example.com:8443/auth`

- if there's no scheme, https:// is added
- only http and https are authorized (I don't see any other scheme that could be used)

There's still a special case (not yet handled) where you're hosting a keycloak server behind the same reverse proxy than your app and you just want to specify "/auth" in KeycloakURL.

I add some unit tests and tried to test it locally, the traefik doc is wrong about how to load local plugins.
"Local Mode" [here](https://plugins.traefik.io/install) use experimental.plugins instead of experimental.localplugins.
But it's correct in the [example plugin](https://github.com/traefik/plugindemo#local-mode)

 I had to do this in my docker-compose.yml:
```yaml
version: "3.9"

services:
  proxy:
    image: traefik:v2.10
    hostname: "proxy-webserver"
    command:
      - --global.checknewversion=false
      - --log=true
      - --log.level=DEBUG
      - --ping
      - --accesslog=true
      - --api.debug=true
      - --api.insecure=true
      - --providers.docker=true
      - --providers.docker.exposedbydefault=false
      - --providers.docker.network=traefik-test
      - --providers.docker.swarmmode=true
      - --providers.file.directory=/etc/traefik
      - --entrypoints.https.address=:10443      
      - --entrypoints.traefik.address=:18081
      - --metrics.prometheus=true
      - --experimental.localplugins.keycloakopenid.modulename=github.com/Gwojda/keycloakopenid
    deploy:
      placement:
        constraints:
          - node.role == manager
    ports:
      - "10443:10443"
      - "18081:18081"
    networks:
      - traefik-test
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock
      - ./etc/traefik:/etc/traefik:ro
      - path/to/keycloakopenid:/plugins-local/src/github.com/Gwojda/keycloakopenid
```
see --experimental.localplugins.... and mounting the directory of the plugin in the right place.

It's my first experience in go, feel free to correct my mistakes.