### PR TITLE
Add support for scope parameter in keyclock authentication | Add TokenCookieName functionality | Add Authorization header functionality

### DIFF
--- a/.traefik.yml
+++ b/.traefik.yml
@@ -8,7 +8,7 @@ type: middleware
 import: github.com/Gwojda/keycloakopenid
 
 # A brief description of what your plugin is doing.
-summary: This plugin for Traefik allows it to authenticate requests against Keycloak. It utilizes the Keycloak's client credentials flow to retrieve an access token, which is then set as a bearer token in the Authorization header of the incoming requests. The plugin communicates with Keycloak using the OpenID Connect protocol.
+summary: This plugin for Traefik allows it to authenticate requests against Keycloak. It utilizes the Keycloak's client credentials flow to retrieve an access token, which is then set as a bearer token in the Authorization cookie and as a plain token in a custom named cookie of the incoming requests. Optionally sets the Bearer token in the Authorization header. The plugin communicates with Keycloak using the OpenID Connect protocol.
 
 # Medias associated to the plugin (optional)
 iconPath: foo/icon.png
@@ -22,6 +22,6 @@ testData:
   ClientID: "<CLIENT_ID"
   ClientSecret: "<CLIENT_SECRET"
   KeycloakRealm: "<REALM"
-  Scope: "<Scope"
+  Scope: "<Scope (space deliminated) (example: 'openid profile email')"
   TokenCookieName: "TOKEN_COOKIE_NAME (default: 'AUTH_TOKEN')"
   UseAuthHeader: "true|false (default: false)"

--- a/.traefik.yml
+++ b/.traefik.yml
@@ -5,7 +5,7 @@ displayName: keycloakopenid
 type: middleware
 
 # The import path of your plugin.
-import: github.com/Fmowers/keycloakopenid
+import: github.com/Gwojda/keycloakopenid
 
 # A brief description of what your plugin is doing.
 summary: This plugin for Traefik allows it to authenticate requests against Keycloak. It utilizes the Keycloak's client credentials flow to retrieve an access token, which is then set as a bearer token in the Authorization header of the incoming requests. The plugin communicates with Keycloak using the OpenID Connect protocol.
@@ -22,4 +22,4 @@ testData:
   ClientID: "<CLIENT_ID"
   ClientSecret: "<CLIENT_SECRET"
   KeycloakRealm: "<REALM"
-  Scope: "<Scope>"
+  Scope: "<Scope"

--- a/.traefik.yml
+++ b/.traefik.yml
@@ -22,6 +22,6 @@ testData:
   ClientID: "<CLIENT_ID"
   ClientSecret: "<CLIENT_SECRET"
   KeycloakRealm: "<REALM"
-  Scope: "<Scope [space deliminated] (default: 'openid', example: 'openid profile email')"
-  TokenCookieName: "TOKEN_COOKIE_NAME (default: 'AUTH_TOKEN')"
-  UseAuthHeader: "true|false (default: false)"
+  Scope: "openid"
+  TokenCookieName: "AUTH_TOKEN"
+  UseAuthHeader: false

--- a/.traefik.yml
+++ b/.traefik.yml
@@ -23,3 +23,4 @@ testData:
   ClientSecret: "<CLIENT_SECRET"
   KeycloakRealm: "<REALM"
   Scope: "<Scope"
+  TokenCookieName: "<TOKEN_COOKIE_NAME"

--- a/.traefik.yml
+++ b/.traefik.yml
@@ -5,7 +5,7 @@ displayName: keycloakopenid
 type: middleware
 
 # The import path of your plugin.
-import: github.com/Gwojda/keycloakopenid
+import: github.com/Fmowers/keycloakopenid
 
 # A brief description of what your plugin is doing.
 summary: This plugin for Traefik allows it to authenticate requests against Keycloak. It utilizes the Keycloak's client credentials flow to retrieve an access token, which is then set as a bearer token in the Authorization header of the incoming requests. The plugin communicates with Keycloak using the OpenID Connect protocol.

--- a/.traefik.yml
+++ b/.traefik.yml
@@ -22,6 +22,6 @@ testData:
   ClientID: "<CLIENT_ID"
   ClientSecret: "<CLIENT_SECRET"
   KeycloakRealm: "<REALM"
-  Scope: "<Scope (space deliminated) (example: 'openid profile email')"
+  Scope: "<Scope [space deliminated] (default: 'openid', example: 'openid profile email')"
   TokenCookieName: "TOKEN_COOKIE_NAME (default: 'AUTH_TOKEN')"
   UseAuthHeader: "true|false (default: false)"

--- a/.traefik.yml
+++ b/.traefik.yml
@@ -23,4 +23,5 @@ testData:
   ClientSecret: "<CLIENT_SECRET"
   KeycloakRealm: "<REALM"
   Scope: "<Scope"
-  TokenCookieName: "<TOKEN_COOKIE_NAME"
+  TokenCookieName: "TOKEN_COOKIE_NAME (default: 'AUTH_TOKEN')"
+  UseAuthHeader: "true|false (default: false)"

--- a/.traefik.yml
+++ b/.traefik.yml
@@ -22,3 +22,4 @@ testData:
   ClientID: "<CLIENT_ID"
   ClientSecret: "<CLIENT_SECRET"
   KeycloakRealm: "<REALM"
+  Scope: "<Scope>"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ http:
           ClientSecret: "<CLIENT_SECRET"
           KeycloakRealm: "<REALM"
           Scope: "<SCOPE"
-          TokenCookieName: "<TOKEN_COOKIE_NAME"
+          TokenCookieName: "<TOKEN_COOKIE_NAME (default: 'AUTH_TOKEN')"
+          UseAuthHeader: "<true|false (default: false)"
 ```
 
 Alternatively, ClientID and ClientSecret can be read from a file to support Docker Secrets and Kubernetes Secrets:
@@ -76,7 +77,8 @@ http:
           ClientSecretFile: "/run/secrets/clientSecret.txt"
           KeycloakRealm: "<REALM"
           Scope: "<SCOPE"
-          TokenCookieName: "<TOKEN_COOKIE_NAME"
+          TokenCookieName: "<TOKEN_COOKIE_NAME (default: 'AUTH_TOKEN')"
+          UseAuthHeader: "<true|false (default: false)"
 ```
 
 Last but not least, each configuration can be read from environment file to support some Kubernetes configurations:
@@ -92,7 +94,7 @@ http:
           ClientSecretEnv: "MY_KEYCLOAK_CLIENT_SECRET"
           KeycloakRealmEnv: "MY_KEYCLOAK_REALM"
           ScopeEnv: "SCOPE"
-          TokenCookieNameEnv: "TOKEN_COOKIE_NAME"
+          TokenCookieNameEnv: "TOKEN_COOKIE_NAME (default: 'AUTH_TOKEN')"
 ```
 
 This plugin also sets a header with a claim from Keycloak, as it has become reasonably common. Claim name and header name can be modified.  
@@ -109,6 +111,8 @@ http:
           ClientSecret: "<CLIENT_SECRET"
           KeycloakRealm: "<REALM"
           Scope: "<SCOPE"
+          TokenCookieName: "TOKEN_COOKIE_NAME (default: "AUTH_TOKEN)"
+          UseAuthHeader: "true|false (default: false)"
           UserClaimName: "my-uncommon-claim"
           UserHeaderName: "X-Custom-Header"
 ```

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ http:
           ClientSecret: "<CLIENT_SECRET"
           KeycloakRealm: "<REALM"
           Scope: "<SCOPE"
+          TokenCookieName: "<TOKEN_COOKIE_NAME"
 ```
 
 Alternatively, ClientID and ClientSecret can be read from a file to support Docker Secrets and Kubernetes Secrets:
@@ -75,6 +76,7 @@ http:
           ClientSecretFile: "/run/secrets/clientSecret.txt"
           KeycloakRealm: "<REALM"
           Scope: "<SCOPE"
+          TokenCookieName: "<TOKEN_COOKIE_NAME"
 ```
 
 Last but not least, each configuration can be read from environment file to support some Kubernetes configurations:
@@ -90,6 +92,7 @@ http:
           ClientSecretEnv: "MY_KEYCLOAK_CLIENT_SECRET"
           KeycloakRealmEnv: "MY_KEYCLOAK_REALM"
           ScopeEnv: "SCOPE"
+          TokenCookieNameEnv: "TOKEN_COOKIE_NAME"
 ```
 
 This plugin also sets a header with a claim from Keycloak, as it has become reasonably common. Claim name and header name can be modified.  

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ http:
           KeycloakRealmEnv: "MY_KEYCLOAK_REALM"
           ScopeEnv: "SCOPE [space deliminated] (default: 'openid', example: 'openid profile email')"
           TokenCookieNameEnv: "TOKEN_COOKIE_NAME (default: 'AUTH_TOKEN')"
+          UseAuthHeaderEnv: "USE_AUTH_HEADER (default: false)"
 ```
 
 This plugin also sets a header with a claim from Keycloak, as it has become reasonably common. Claim name and header name can be modified.  

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ http:
           Scope: "<Scope [space deliminated] (default: 'openid', example: 'openid profile email')"
           TokenCookieName: "<TOKEN_COOKIE_NAME (default: 'AUTH_TOKEN')"
           UseAuthHeader: "<true|false (default: false)"
+          IgnorePathPrefixes: "/api,/favicon.ico [comma deliminated] (optional)"
 ```
 
 Alternatively, ClientID and ClientSecret can be read from a file to support Docker Secrets and Kubernetes Secrets:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ http:
           ClientID: "<CLIENT_ID"
           ClientSecret: "<CLIENT_SECRET"
           KeycloakRealm: "<REALM"
-          Scope: "<Scope (space deliminated) (example: 'openid profile email')"
+          Scope: "<Scope [space deliminated] (default: 'openid', example: 'openid profile email')"
           TokenCookieName: "<TOKEN_COOKIE_NAME (default: 'AUTH_TOKEN')"
           UseAuthHeader: "<true|false (default: false)"
 ```
@@ -76,7 +76,7 @@ http:
           ClientIDFile: "/run/secrets/clientId.txt"
           ClientSecretFile: "/run/secrets/clientSecret.txt"
           KeycloakRealm: "<REALM"
-          Scope: "<SCOPE (space deliminated) (example: 'openid profile email')"
+          Scope: "<SCOPE [space deliminated] (default: 'openid', example: 'openid profile email')"
           TokenCookieName: "<TOKEN_COOKIE_NAME (default: 'AUTH_TOKEN')"
           UseAuthHeader: "<true|false (default: false)"
 ```
@@ -93,7 +93,7 @@ http:
           ClientIDEnv: "MY_KEYCLOAK_CLIENT_ID"
           ClientSecretEnv: "MY_KEYCLOAK_CLIENT_SECRET"
           KeycloakRealmEnv: "MY_KEYCLOAK_REALM"
-          ScopeEnv: "SCOPE (space deliminated) (example: 'openid profile email')"
+          ScopeEnv: "SCOPE [space deliminated] (default: 'openid', example: 'openid profile email')"
           TokenCookieNameEnv: "TOKEN_COOKIE_NAME (default: 'AUTH_TOKEN')"
 ```
 
@@ -110,7 +110,7 @@ http:
           ClientID: "<CLIENT_ID"
           ClientSecret: "<CLIENT_SECRET"
           KeycloakRealm: "<REALM"
-          Scope: "<SCOPE (space deliminated) (example: 'openid profile email')"
+          Scope: "<SCOPE [space deliminated] (default: 'openid', example: 'openid profile email')"
           TokenCookieName: "TOKEN_COOKIE_NAME (default: "AUTH_TOKEN)"
           UseAuthHeader: "true|false (default: false)"
           UserClaimName: "my-uncommon-claim"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ http:
           ClientID: "<CLIENT_ID"
           ClientSecret: "<CLIENT_SECRET"
           KeycloakRealm: "<REALM"
-          Scope: "<SCOPE"
+          Scope: "<Scope (space deliminated) (example: 'openid profile email')"
           TokenCookieName: "<TOKEN_COOKIE_NAME (default: 'AUTH_TOKEN')"
           UseAuthHeader: "<true|false (default: false)"
 ```
@@ -76,7 +76,7 @@ http:
           ClientIDFile: "/run/secrets/clientId.txt"
           ClientSecretFile: "/run/secrets/clientSecret.txt"
           KeycloakRealm: "<REALM"
-          Scope: "<SCOPE"
+          Scope: "<SCOPE (space deliminated) (example: 'openid profile email')"
           TokenCookieName: "<TOKEN_COOKIE_NAME (default: 'AUTH_TOKEN')"
           UseAuthHeader: "<true|false (default: false)"
 ```
@@ -93,7 +93,7 @@ http:
           ClientIDEnv: "MY_KEYCLOAK_CLIENT_ID"
           ClientSecretEnv: "MY_KEYCLOAK_CLIENT_SECRET"
           KeycloakRealmEnv: "MY_KEYCLOAK_REALM"
-          ScopeEnv: "SCOPE"
+          ScopeEnv: "SCOPE (space deliminated) (example: 'openid profile email')"
           TokenCookieNameEnv: "TOKEN_COOKIE_NAME (default: 'AUTH_TOKEN')"
 ```
 
@@ -110,7 +110,7 @@ http:
           ClientID: "<CLIENT_ID"
           ClientSecret: "<CLIENT_SECRET"
           KeycloakRealm: "<REALM"
-          Scope: "<SCOPE"
+          Scope: "<SCOPE (space deliminated) (example: 'openid profile email')"
           TokenCookieName: "TOKEN_COOKIE_NAME (default: "AUTH_TOKEN)"
           UseAuthHeader: "true|false (default: false)"
           UserClaimName: "my-uncommon-claim"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ experimental:
   plugins:
     keycloakopenid:
       moduleName: "github.com/Gwojda/keycloakopenid"
-      version: "v0.1.32"
+      version: "v0.1.34"
 ```
 
 Usage
@@ -59,6 +59,7 @@ http:
           ClientID: "<CLIENT_ID"
           ClientSecret: "<CLIENT_SECRET"
           KeycloakRealm: "<REALM"
+          Scope: "<SCOPE"
 ```
 
 Alternatively, ClientID and ClientSecret can be read from a file to support Docker Secrets and Kubernetes Secrets:
@@ -73,6 +74,7 @@ http:
           ClientIDFile: "/run/secrets/clientId.txt"
           ClientSecretFile: "/run/secrets/clientSecret.txt"
           KeycloakRealm: "<REALM"
+          Scope: "<SCOPE"
 ```
 
 Last but not least, each configuration can be read from environment file to support some Kubernetes configurations:
@@ -87,6 +89,7 @@ http:
           ClientIDEnv: "MY_KEYCLOAK_CLIENT_ID"
           ClientSecretEnv: "MY_KEYCLOAK_CLIENT_SECRET"
           KeycloakRealmEnv: "MY_KEYCLOAK_REALM"
+          ScopeEnv: "SCOPE"
 ```
 
 This plugin also sets a header with a claim from Keycloak, as it has become reasonably common. Claim name and header name can be modified.  
@@ -102,6 +105,7 @@ http:
           ClientID: "<CLIENT_ID"
           ClientSecret: "<CLIENT_SECRET"
           KeycloakRealm: "<REALM"
+          Scope: "<SCOPE"
           UserClaimName: "my-uncommon-claim"
           UserHeaderName: "X-Custom-Header"
 ```

--- a/config_parser.go
+++ b/config_parser.go
@@ -29,6 +29,7 @@ type Config struct {
 	KeycloakRealmEnv   string `json:"keycloak_realm_env"`
 	ScopeEnv           string `json:"scope_env"`
 	TokenCookieNameEnv string `json:"token_cookie_name_env"`
+	UseAuthHeaderEnv   bool   `json:"use_auth_header_env"`
 }
 
 type keycloakAuth struct {
@@ -143,6 +144,16 @@ func readConfigEnv(config *Config) error {
 		}
 		config.TokenCookieName = strings.TrimSpace(tokenCookieName)
 	}
+	
+	useAuthHeader, exists := os.LookupEnv(config.UseAuthHeaderEnv)
+	
+	if !exists {
+		useAuthHeader := false
+	}
+
+	useAuthHeader = strings.ToLower(useAuthHeader)
+	config.UseAuthHeaderEnv = useAuthHeader == "true" || useAuthHeader == "1"
+	
 	return nil
 }
 

--- a/config_parser.go
+++ b/config_parser.go
@@ -165,6 +165,10 @@ func New(uctx context.Context, next http.Handler, config *Config, name string) (
 		return nil, err
 	}
 
+	if config.Scope == "" {
+		config.Scope = "openid"
+	}
+
 	tokenCookieName := "AUTH_TOKEN"
 	if config.TokenCookieName != "" {
 		tokenCookieName = config.TokenCookieName

--- a/config_parser.go
+++ b/config_parser.go
@@ -15,6 +15,7 @@ type Config struct {
 	ClientID       string `json:"client_id"`
 	ClientSecret   string `json:"client_secret"`
 	KeycloakRealm  string `json:"keycloak_realm"`
+	Scope          string `json:"scope"`
 	UserClaimName  string `json:"user_claim_name"`
 	UserHeaderName string `json:"user_header_name"`
 
@@ -32,6 +33,7 @@ type keycloakAuth struct {
 	ClientID       string
 	ClientSecret   string
 	KeycloakRealm  string
+	Scope          string
 	UserClaimName  string
 	UserHeaderName string
 }
@@ -159,6 +161,7 @@ func New(uctx context.Context, next http.Handler, config *Config, name string) (
 		ClientID:      config.ClientID,
 		ClientSecret:  config.ClientSecret,
 		KeycloakRealm: config.KeycloakRealm,
+		Scope:         config.Scope,
 		UserClaimName: userClaimName,
 		UserHeaderName: userHeaderName,
 	}, nil

--- a/config_parser.go
+++ b/config_parser.go
@@ -30,7 +30,7 @@ type Config struct {
 	KeycloakRealmEnv      string `json:"keycloak_realm_env"`
 	ScopeEnv              string `json:"scope_env"`
 	TokenCookieNameEnv    string `json:"token_cookie_name_env"`
-	UseAuthHeaderEnv      string   `json:"use_auth_header_env"`
+	UseAuthHeaderEnv      string `json:"use_auth_header_env"`
 	IgnorePathPrefixesEnv string `json:"ignore_path_prefixes_env"`
 }
 

--- a/config_parser.go
+++ b/config_parser.go
@@ -144,15 +144,16 @@ func readConfigEnv(config *Config) error {
 		}
 		config.TokenCookieName = strings.TrimSpace(tokenCookieName)
 	}
-	
-	useAuthHeader, exists := os.LookupEnv(config.UseAuthHeaderEnv)
-	
-	if !exists {
-		useAuthHeader := false
-	}
+	if config.TokenCookieNameEnv != "" {
+		useAuthHeader, exists := os.LookupEnv(config.UseAuthHeaderEnv)
+		
+		if !exists {
+			useAuthHeader := false
+		}
 
-	useAuthHeader = strings.ToLower(useAuthHeader)
-	config.UseAuthHeaderEnv = useAuthHeader == "true" || useAuthHeader == "1"
+		useAuthHeader = strings.ToLower(useAuthHeader)
+		config.UseAuthHeader = useAuthHeader == "true" || useAuthHeader == "1"
+	}
 	
 	return nil
 }

--- a/config_parser.go
+++ b/config_parser.go
@@ -17,6 +17,7 @@ type Config struct {
 	KeycloakRealm   string `json:"keycloak_realm"`
 	Scope           string `json:"scope"`
 	TokenCookieName string `json:"token_cookie_name"`
+	UseAuthHeader   bool   `json:"use_auth_header"`
 	UserClaimName   string `json:"user_claim_name"`
 	UserHeaderName  string `json:"user_header_name"`
 
@@ -38,6 +39,7 @@ type keycloakAuth struct {
 	KeycloakRealm   string
 	Scope           string
 	TokenCookieName string
+	UseAuthHeader	  bool
 	UserClaimName   string
 	UserHeaderName  string
 }
@@ -168,6 +170,11 @@ func New(uctx context.Context, next http.Handler, config *Config, name string) (
 		tokenCookieName = config.TokenCookieName
 	}
 
+	useAuthHeader := false
+	if config.UseAuthHeader {
+		useAuthHeader = true
+	}
+
 	userClaimName := "preferred_username"
 	if config.UserClaimName != "" {
 		userClaimName = config.UserClaimName
@@ -186,6 +193,7 @@ func New(uctx context.Context, next http.Handler, config *Config, name string) (
 		KeycloakRealm:   config.KeycloakRealm,
 		Scope:           config.Scope,
 		TokenCookieName: tokenCookieName,
+		UseAuthHeader:   useAuthHeader,
 		UserClaimName:   userClaimName,
 		UserHeaderName:  userHeaderName,
 	}, nil

--- a/config_parser.go
+++ b/config_parser.go
@@ -25,6 +25,7 @@ type Config struct {
 	ClientIDEnv       string `json:"client_id_env"`
 	ClientSecretEnv   string `json:"client_secret_env"`
 	KeycloakRealmEnv  string `json:"keycloak_realm_env"`
+	ScopeEnv          string `json:"scope_env"`
 }
 
 type keycloakAuth struct {
@@ -122,6 +123,13 @@ func readConfigEnv(config *Config) error {
 			return errors.New("KeycloakRealmEnv referenced but NOT set")
 		}
 		config.KeycloakRealm = strings.TrimSpace(keycloakRealm)
+	}
+	if config.ScopeEnv != "" {
+		scope := os.Getenv(config.ScopeEnv)
+		if scope == "" {
+			return errors.New("ScopeEnv referenced but NOT set")
+		}
+		config.Scope = strings.TrimSpace(scope)
 	}
 	return nil
 }

--- a/config_parser.go
+++ b/config_parser.go
@@ -11,15 +11,15 @@ import (
 )
 
 type Config struct {
-	KeycloakURL     	 string `json:"url"`
-	ClientID        	 string `json:"client_id"`
-	ClientSecret    	 string `json:"client_secret"`
-	KeycloakRealm   	 string `json:"keycloak_realm"`
+	KeycloakURL        string `json:"url"`
+	ClientID           string `json:"client_id"`
+	ClientSecret       string `json:"client_secret"`
+	KeycloakRealm      string `json:"keycloak_realm"`
 	Scope              string `json:"scope"`
 	TokenCookieName    string `json:"token_cookie_name"`
 	UseAuthHeader      bool   `json:"use_auth_header"`
-	UserClaimName   	 string `json:"user_claim_name"`
-	UserHeaderName  	 string `json:"user_header_name"`
+	UserClaimName      string `json:"user_claim_name"`
+	UserHeaderName     string `json:"user_header_name"`
 	IgnorePathPrefixes string `json:"ignore_path_prefixes"`
 
 	ClientIDFile          string `json:"client_id_file"`

--- a/config_parser.go
+++ b/config_parser.go
@@ -139,7 +139,7 @@ func readConfigEnv(config *Config) error {
 		if tokenCookieName == "" {
 			return errors.New("TokenCookieNameEnv referenced but NOT set")
 		}
-		config.TokenCookieName = tokenCookieName
+		config.TokenCookieName = strings.TrimSpace(tokenCookieName)
 	}
 	return nil
 }

--- a/config_parser.go
+++ b/config_parser.go
@@ -146,15 +146,12 @@ func readConfigEnv(config *Config) error {
 	}
 	if config.TokenCookieNameEnv != "" {
 		useAuthHeader, exists := os.LookupEnv(config.UseAuthHeaderEnv)
-		
 		if !exists {
 			useAuthHeader := false
 		}
-
 		useAuthHeader = strings.ToLower(useAuthHeader)
 		config.UseAuthHeader = useAuthHeader == "true" || useAuthHeader == "1"
 	}
-	
 	return nil
 }
 

--- a/config_parser.go
+++ b/config_parser.go
@@ -129,7 +129,7 @@ func readConfigEnv(config *Config) error {
 		if scope == "" {
 			return errors.New("ScopeEnv referenced but NOT set")
 		}
-		config.Scope = strings.TrimSpace(scope)
+		config.Scope = scope //Do not trim space here as it is common to use space as a separator and should be properly escaped when encoded
 	}
 	return nil
 }

--- a/config_parser.go
+++ b/config_parser.go
@@ -15,9 +15,9 @@ type Config struct {
 	ClientID        	 string `json:"client_id"`
 	ClientSecret    	 string `json:"client_secret"`
 	KeycloakRealm   	 string `json:"keycloak_realm"`
-	Scope           	 string `json:"scope"`
-	TokenCookieName 	 string `json:"token_cookie_name"`
-	UseAuthHeader   	 bool   `json:"use_auth_header"`
+	Scope              string `json:"scope"`
+	TokenCookieName    string `json:"token_cookie_name"`
+	UseAuthHeader      bool   `json:"use_auth_header"`
 	UserClaimName   	 string `json:"user_claim_name"`
 	UserHeaderName  	 string `json:"user_header_name"`
 	IgnorePathPrefixes string `json:"ignore_path_prefixes"`
@@ -42,7 +42,7 @@ type keycloakAuth struct {
 	KeycloakRealm      string
 	Scope              string
 	TokenCookieName    string
-	UseAuthHeader	     bool
+	UseAuthHeader      bool
 	UserClaimName      string
 	UserHeaderName     string
 	IgnorePathPrefixes []string

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/Gwojda/keycloakopenid
+module github.com/Fmowers/keycloakopenid
 
 go 1.19

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/Fmowers/keycloakopenid
+module github.com/Gwojda/keycloakopenid
 
 go 1.19

--- a/main.go
+++ b/main.go
@@ -185,6 +185,7 @@ func (k *keycloakAuth) redirectToKeycloak(rw http.ResponseWriter, req *http.Requ
 		"client_id":     {k.ClientID},
 		"redirect_uri":  {originalURL},
 		"state":         {stateBase64},
+		"scope":				 {k.Scope},
 	}.Encode()
 
 	http.Redirect(rw, req, redirectURL.String(), http.StatusFound)

--- a/main.go
+++ b/main.go
@@ -13,6 +13,12 @@ import (
 )
 
 func (k *keycloakAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	for _, substr := range k.IgnorePathPrefixes {
+			if strings.Contains(req.URL.Path, substr) {
+					k.next.ServeHTTP(rw, req)
+					return
+			}
+	}
 	cookie, err := req.Cookie("Authorization")
 	if err == nil && strings.HasPrefix(cookie.Value, "Bearer ") {
 		token := strings.TrimPrefix(cookie.Value, "Bearer ")

--- a/main.go
+++ b/main.go
@@ -74,10 +74,11 @@ func (k *keycloakAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		// Not sure why this is being set as a cookie instead of its common use as a header
-		req.Header.Set("Authorization", "Bearer " + token)
+		if k.UseAuthHeader {
+			// Optionally set the Bearer token to the Authorization header.
+			req.Header.Set("Authorization", "Bearer " + token)
+		}
 
-		// Keep to maintain backwards compatibility
 		http.SetCookie(rw, &http.Cookie{
 			Name:     "Authorization",
 			Value:    "Bearer " + token,

--- a/main.go
+++ b/main.go
@@ -74,9 +74,23 @@ func (k *keycloakAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			return
 		}
 
+		// Not sure why this is being set as a cookie instead of its common use as a header
+		req.Header.Set("Authorization", "Bearer " + token)
+
+		// Keep to maintain backwards compatibility
 		http.SetCookie(rw, &http.Cookie{
 			Name:     "Authorization",
 			Value:    "Bearer " + token,
+			Secure:   true,
+			HttpOnly: true,
+			Path:     "/",
+			SameSite: http.SameSiteStrictMode,
+		})
+
+		// Set the token to a default/custom cookie that doesnt require trimming the Bearer prefix for common integration compatibility
+		http.SetCookie(rw, &http.Cookie{
+			Name:     k.TokenCookieName, // Defaults to "AUTH_TOKEN"
+			Value:    token,
 			Secure:   true,
 			HttpOnly: true,
 			Path:     "/",

--- a/main.go
+++ b/main.go
@@ -14,10 +14,10 @@ import (
 
 func (k *keycloakAuth) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	for _, substr := range k.IgnorePathPrefixes {
-			if strings.Contains(req.URL.Path, substr) {
-					k.next.ServeHTTP(rw, req)
-					return
-			}
+		if strings.Contains(req.URL.Path, substr) {
+			k.next.ServeHTTP(rw, req)
+			return
+		}
 	}
 	cookie, err := req.Cookie("Authorization")
 	if err == nil && strings.HasPrefix(cookie.Value, "Bearer ") {

--- a/main_test.go
+++ b/main_test.go
@@ -15,7 +15,7 @@ func TestServeHTTP(t *testing.T) {
 	config.KeycloakRealm = "bochsler"
 	config.ClientID = "keycloakMiddleware"
 	config.ClientSecret = "uc0yKKpQsOqhggsG4eK7mDU3glT81chn"
-	config.Scope = "openid"
+	config.Scope = "openid profile email"
 
 	// Create a new instance of our middleware
 	keycloakMiddleware, err := New(context.TODO(), http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {

--- a/main_test.go
+++ b/main_test.go
@@ -15,6 +15,7 @@ func TestServeHTTP(t *testing.T) {
 	config.KeycloakRealm = "bochsler"
 	config.ClientID = "keycloakMiddleware"
 	config.ClientSecret = "uc0yKKpQsOqhggsG4eK7mDU3glT81chn"
+	config.Scope = "openid"
 
 	// Create a new instance of our middleware
 	keycloakMiddleware, err := New(context.TODO(), http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
- Added Scope parameter to config
- Added TokenCookieName to config
- Added UseAuthHeader to config
- Sets token as a direct value of a default cookiename ("AUTH_TOKEN") or the value of the TokenCookieName config value
- Optionally sets the Authorization Bearer {token} as a header to match other common implementations of this pattern

Many third party applications that offer external authentication integration require an externalCookieName where it looks for the access token, without the Bearer prefix, to use when calling the userinfo url. Some of them use the Authorization header to look for a Bearer token instead of or as a fall back option when they cant find the token through the cookie.

Given that setting the Bearer token as a header can have security implications outside the scope of this plugin. Making it optional, with the default behavior not using the header, seems prudent.

It would not let me test this using my github url first. So these changes have not been tested other than by running the `main_test.go` file. 