### PR TITLE
Add support of kc_idp_hint keycloak query parameter

### DIFF
--- a/config_parser.go
+++ b/config_parser.go
@@ -16,6 +16,7 @@ type Config struct {
 	ClientSecret       string `json:"client_secret"`
 	KeycloakRealm      string `json:"keycloak_realm"`
 	Scope              string `json:"scope"`
+	KcIdpHint          string `json:"kc_idp_hint"`
 	TokenCookieName    string `json:"token_cookie_name"`
 	UseAuthHeader      bool   `json:"use_auth_header"`
 	UserClaimName      string `json:"user_claim_name"`
@@ -41,6 +42,7 @@ type keycloakAuth struct {
 	ClientSecret       string
 	KeycloakRealm      string
 	Scope              string
+	KcIdpHint          string
 	TokenCookieName    string
 	UseAuthHeader      bool
 	UserClaimName      string
@@ -220,6 +222,7 @@ func New(uctx context.Context, next http.Handler, config *Config, name string) (
 		ClientSecret:       config.ClientSecret,
 		KeycloakRealm:      config.KeycloakRealm,
 		Scope:              config.Scope,
+		KcIdpHint:          config.KcIdpHint,
 		TokenCookieName:    tokenCookieName,
 		UseAuthHeader:      useAuthHeader,
 		UserClaimName:      userClaimName,


### PR DESCRIPTION
This Pull Request is to add support for kc_idp_hint keycloak query parameter.

Here is the full description of how to use this parameter in keycloak:
https://www.keycloak.org/docs/latest/server_admin/index.html#_client_suggested_idp

When this parameter is not provided, default identity provider is requested. But one may be in a situation where several identity providers are configured in keycloak. In that case it may be useful to request a specific one with the kc_idp_hint query parameter. Keycloak in that case redirects the request to the requested identity provider.

Description of the PR:
 - If, in the original url, a query parameter named "idp" is provided (the value must a keycloak idp alias), This idp query parameter value is taken unchanged, and set as kc_idp_hint query parameter value in the keycloak auth request.
 - a default kc_idp_hint value can also be set in the config of the middleware
 - If an idp query parameter is provided in the original url and a kc_idp_hint is provided in the config of the middleware, the idp query parameter takes precedence over the defaut kc_idp_hint config